### PR TITLE
ci: fix Codecov token configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,5 +32,4 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -41,7 +41,7 @@ Failures in any step block merges. Extend this workflow when adding new tools
 ## Coverage Reporting
 
 - The `Coverage` workflow ([.github/workflows/coverage.yml](../.github/workflows/coverage.yml)) runs pytest with coverage and uploads the report to Codecov.
-- Configure the `CODECOV_TOKEN` repository secret before relying on the status check.
+- Configure the `CODECOV_TOKEN` repository secret; the workflow passes it via the action input.
 - Coverage thresholds are defined in `codecov.yml`.
 
 ## Future Automation Ideas


### PR DESCRIPTION
Ensures the coverage workflow passes CODECOV_TOKEN via action inputs and updates docs.