### PR TITLE
ci: upload Codecov test results

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,11 +25,18 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=cadmu --cov-report=xml
+          pytest --cov=cadmu --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -41,7 +41,8 @@ Failures in any step block merges. Extend this workflow when adding new tools
 ## Coverage Reporting
 
 - The `Coverage` workflow ([.github/workflows/coverage.yml](../.github/workflows/coverage.yml)) runs pytest with coverage and uploads the report to Codecov.
-- Configure the `CODECOV_TOKEN` repository secret; the workflow passes it via the action input.
+- Configure the `CODECOV_TOKEN` repository secret; the workflow passes it via the action inputs.
+- JUnit results (`junit.xml`) are also uploaded using `codecov/test-results-action@v1` so Codecov can surface flaky tests and timing data.
 - Coverage thresholds are defined in `codecov.yml`.
 
 ## Future Automation Ideas


### PR DESCRIPTION
Adds JUnit output and uses codecov/test-results-action to send test results to Codecov.